### PR TITLE
:zap:Add notification feature & provider, update socket handlers

### DIFF
--- a/app/(platform)/layout.tsx
+++ b/app/(platform)/layout.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from "next";
 import SocketProvider from "@/providers/socket_provider";
+import ReactQueryProvider from "@/providers/react_query_provider";
+import { NotificationProvider } from "@/providers/notification_provider";
 import { cookies } from "next/headers";
 import ClientWrapper from "../client_wrapper";
-import ReactQueryProvider from "@/providers/react_query_provider";
 import { Header } from "@layout";
 
 export const metadata: Metadata = {
@@ -20,12 +21,14 @@ export default async function RootLayout({
   const token = cookieStore.get("donor_token")?.value || null;
   return (
     <ClientWrapper donorId={donorId} token={token}>
-      <SocketProvider>
-        <ReactQueryProvider>
-          <Header />
-          {children}
-        </ReactQueryProvider>
-      </SocketProvider>
+      <ReactQueryProvider>
+        <NotificationProvider>
+          <SocketProvider>
+            <Header />
+            {children}
+          </SocketProvider>
+        </NotificationProvider>
+      </ReactQueryProvider>
     </ClientWrapper>
   );
 }

--- a/components/layout/Header/Header.tsx
+++ b/components/layout/Header/Header.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import UserHooks from "@UserHooks";
 import { HeaderNavLinks } from "./HeaderNavLinks";
 import { MobileMenuDrawer } from "./MobileMenuDrawer";
-
+import NotificationDrawer from "./NotificationDrawer";
 export default function Header() {
   const [donorId, setDonorId] = useState("");
   const userType = "donor";
@@ -31,7 +31,7 @@ export default function Header() {
       <div className="font-bold text-gray-700 text-lg select-none">
         MealBridge
       </div>
-      <HeaderNavLinks  donorId = {donorId}/>
+      <HeaderNavLinks donorId={donorId} />
       <div className="sm:hidden">
         <MobileMenuDrawer
           userData={data}
@@ -39,6 +39,7 @@ export default function Header() {
           onChange={setIsSheetOpen}
         />
       </div>
+      <NotificationDrawer />
     </nav>
   );
 }

--- a/components/layout/Header/HeaderNavLinks.tsx
+++ b/components/layout/Header/HeaderNavLinks.tsx
@@ -1,7 +1,9 @@
 import Link from "next/link";
-import { LogOutButton } from "@atoms";
+import { Bell } from "lucide-react";
+import { useNotifications } from "@/providers/notification_provider";
 
 export function HeaderNavLinks({ donorId }: { donorId: string }) {
+  const { hasUnseenNotifications, setIsDrawerOpen } = useNotifications();
   return (
     <ul className="hidden sm:flex gap-8 items-center font-medium text-gray-700">
       <li className="px-4 py-2 cursor-pointer border-b-2 border-transparent hover:text-[#005e38] hover:border-[#005e38] transition-colors duration-300 select-none">
@@ -13,7 +15,15 @@ export function HeaderNavLinks({ donorId }: { donorId: string }) {
       <li className="px-4 py-2 cursor-pointer border-b-2 border-transparent hover:text-[#005e38] hover:border-[#005e38] transition-colors duration-300 select-none">
         <Link href={"/my-meals-history"}>History</Link>
       </li>
-      <LogOutButton />
+      <li
+        className="relative cursor-pointer"
+        onClick={() => setIsDrawerOpen(true)}
+      >
+        <Bell className="w-5 h-5" />
+        {hasUnseenNotifications && (
+          <span className="absolute -top-1 -right-1 w-2 h-2 rounded-full bg-red-500" />
+        )}
+      </li>
     </ul>
   );
 }

--- a/components/layout/Header/NotificationDrawer.tsx
+++ b/components/layout/Header/NotificationDrawer.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { useNotifications } from "@/providers/notification_provider";
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from "@ui";
+import { cn } from "@/lib/utils";
+
+const getNotificationStyle = (type: string) => {
+  switch (type) {
+    case "meal_booked":
+      return "bg-[#f3fef9] border-[#005e38]";
+    case "meal_received":
+      return "bg-[#f3fef9] border-[#005e38]";
+    case "meal_expired":
+      return "bg-[#fff5f5] border-[#cc0000]";
+    case "meal_reservation_cancelled_by_collector":
+      return "bg-[#fff7ed] border-[#d97706]";
+    default:
+      return "bg-gray-50 border-gray-300";
+  }
+};
+
+export default function NotificationDrawer() {
+  const { notifications, isDrawerOpen, setIsDrawerOpen, removeNotification } =
+    useNotifications();
+
+  return (
+    <Drawer open={isDrawerOpen} onOpenChange={setIsDrawerOpen}>
+      <DrawerContent className="rounded-t-2xl px-4 pb-4 pt-2 min-h-[40vh]">
+        <DrawerHeader>
+          <DrawerTitle className="text-xl font-bold text-center text-[#005e38]">
+            Notifications
+          </DrawerTitle>
+        </DrawerHeader>
+
+        <div className="w-full flex justify-center">
+          <div className="w-full max-w-[600px] space-y-4 overflow-y-auto px-1">
+            {notifications.length === 0 ? (
+              <p className="text-sm text-gray-500 text-center">
+                No new notifications.
+              </p>
+            ) : (
+              notifications.map((n) => (
+                <div
+                  key={n.id}
+                  className={cn(
+                    "flex items-start gap-3 p-3 rounded-xl border",
+                    getNotificationStyle(n.type)
+                  )}
+                >
+                  {n.image && (
+                    <div className="min-w-[60px] h-[60px] relative rounded-md overflow-hidden">
+                      <Image
+                        src={n.image}
+                        alt="Meal"
+                        fill
+                        className="object-cover"
+                      />
+                    </div>
+                  )}
+
+                  <div className="flex-1">
+                    <Link
+                      href={n.link}
+                      onClick={() => setIsDrawerOpen(false)}
+                      className="block font-semibold text-sm text-[#005e38] hover:underline"
+                    >
+                      {n.title}
+                    </Link>
+                    <p className="text-sm text-gray-700">{n.message}</p>
+                    {n.foodDesc && (
+                      <p className="text-xs text-gray-500 mt-1 italic line-clamp-2">
+                        “{n.foodDesc}”
+                      </p>
+                    )}
+                  </div>
+
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-red-500"
+                    onClick={() => removeNotification(n.id)}
+                  >
+                    ×
+                  </Button>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/components/ui/drawer.tsx
+++ b/components/ui/drawer.tsx
@@ -1,0 +1,135 @@
+"use client"
+
+import * as React from "react"
+import { Drawer as DrawerPrimitive } from "vaul"
+
+import { cn } from "@/lib/utils"
+
+function Drawer({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+}
+
+function DrawerTrigger({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />
+}
+
+function DrawerPortal({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />
+}
+
+function DrawerClose({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />
+}
+
+function DrawerOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+  return (
+    <DrawerPrimitive.Overlay
+      data-slot="drawer-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DrawerContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+  return (
+    <DrawerPortal data-slot="drawer-portal">
+      <DrawerOverlay />
+      <DrawerPrimitive.Content
+        data-slot="drawer-content"
+        className={cn(
+          "group/drawer-content bg-background fixed z-50 flex h-auto flex-col",
+          "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
+          "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
+          "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",
+          "data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm",
+          className
+        )}
+        {...props}
+      >
+        <div className="bg-muted mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  )
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-header"
+      className={cn(
+        "flex flex-col gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-1.5 md:text-left",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function DrawerTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+  return (
+    <DrawerPrimitive.Title
+      data-slot="drawer-title"
+      className={cn("text-foreground font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DrawerDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+  return (
+    <DrawerPrimitive.Description
+      data-slot="drawer-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+}

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -40,6 +40,18 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "./dialog";
+import {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+} from "./drawer";
 
 export {
   Button,
@@ -81,4 +93,14 @@ export {
   DialogPortal,
   DialogTitle,
   DialogTrigger,
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
 };

--- a/events/handleMealBooked.ts
+++ b/events/handleMealBooked.ts
@@ -1,0 +1,33 @@
+import { toast } from "sonner";
+import { Notification } from "@/providers/notification_provider";
+import { QueryClient } from "@tanstack/react-query";
+
+export interface MealBookedEventPayload {
+  mealId: string;
+  collectorId: string;
+  message: string;
+  foodDesc: string;
+  image: string;
+}
+
+export default function handleMealBooked(
+  data: MealBookedEventPayload,
+  queryClient: QueryClient
+): Notification {
+  toast.success(data.message || "A meal was booked");
+
+  queryClient.invalidateQueries({ queryKey: ["get-active-meal"] });
+  queryClient.invalidateQueries({
+    queryKey: ["get-active-meal-detail", data.mealId],
+  });
+
+  return {
+    id: `${Date.now()}_${Math.random().toString(36).slice(2)}`,
+    title: "Meal Booked",
+    message: data.message || "Someone booked your meal.",
+    link: `/my-active-meals/${data.mealId}`,
+    image: data.image,
+    foodDesc: data.foodDesc,
+    type: "meal_booked",
+  };
+}

--- a/events/handleMealExpired.ts
+++ b/events/handleMealExpired.ts
@@ -1,0 +1,30 @@
+import { toast } from "sonner";
+import { Notification } from "@/providers/notification_provider";
+import { QueryClient } from "@tanstack/react-query";
+
+export interface MealExpiredEventPayload {
+  mealId: string;
+  message: string;
+  foodDesc?: string;
+  image?: string;
+}
+
+export default function handleMealExpired(
+  data: MealExpiredEventPayload,
+  queryClient: QueryClient
+): Notification {
+  toast.error(data.message || "Meal expired");
+
+  queryClient.invalidateQueries({ queryKey: ["get-active-meal"] });
+  queryClient.invalidateQueries({ queryKey: ["get-meal-history"] });
+
+  return {
+    id: Date.now().toString(),
+    title: "Meal Expired",
+    message: data.message || "Your listed meal has expired.",
+    link: `/my-meals-history/${data.mealId}`,
+    image: data.image,
+    foodDesc: data.foodDesc,
+    type: "meal_expired",
+  };
+}

--- a/events/handleMealReceived.ts
+++ b/events/handleMealReceived.ts
@@ -1,0 +1,35 @@
+import { toast } from "sonner";
+import { Notification } from "@/providers/notification_provider";
+import { QueryClient } from "@tanstack/react-query";
+
+export interface MealReceivedEventPayload {
+  mealId: string;
+  collectorId: string;
+  collectorName: string;
+  message: string;
+  foodDesc?: string;
+  image?: string;
+}
+
+export default function handleMealReceived(
+  data: MealReceivedEventPayload,
+  queryClient: QueryClient
+): Notification {
+  toast.success(data.message || "Meal successfully received");
+
+  queryClient.invalidateQueries({ queryKey: ["get-active-meal"] });
+  queryClient.invalidateQueries({
+    queryKey: ["get-active-meal-detail", data.mealId],
+  });
+  queryClient.invalidateQueries({ queryKey: ["get-meal-history"] });
+
+  return {
+    id: Date.now().toString(),
+    title: "Meal Received",
+    message: data.message || `${data.collectorName} has received your meal.`,
+    link: `/my-meals-history/${data.mealId}`,
+    image: data.image,
+    foodDesc: data.foodDesc,
+    type: "meal_received",
+  };
+}

--- a/events/handleMealReservationCancelledByCollector.ts
+++ b/events/handleMealReservationCancelledByCollector.ts
@@ -1,0 +1,35 @@
+import { toast } from "sonner";
+import { Notification } from "@/providers/notification_provider";
+import { QueryClient } from "@tanstack/react-query";
+
+export interface MealReservationCancelledByCollectorPayload {
+  mealId: string;
+  collectorId: string;
+  collectorName: string;
+  message: string;
+  foodDesc: string;
+  image: string;
+}
+
+export default function handleMealReservationCancelledByCollector(
+  data: MealReservationCancelledByCollectorPayload,
+  queryClient: QueryClient
+): Notification {
+  toast.warning(data.message || "A meal reservation was cancelled.");
+
+  queryClient.invalidateQueries({ queryKey: ["get-active-meal"] });
+  queryClient.invalidateQueries({
+    queryKey: ["get-active-meal-detail", data.mealId],
+  });
+
+  return {
+    id: `${Date.now()}_${Math.random().toString(36).slice(2)}`,
+    title: "Reservation Cancelled",
+    message:
+      data.message || `${data.collectorName} cancelled their reservation.`,
+    link: `/my-active-meals/${data.mealId}`,
+    image: data.image,
+    foodDesc: data.foodDesc,
+    type: "meal_reservation_cancelled_by_collector",
+  };
+}

--- a/events/index.ts
+++ b/events/index.ts
@@ -1,0 +1,10 @@
+import handleMealBooked from "./handleMealBooked";
+import handleMealReservationCancelledByCollector from "./handleMealReservationCancelledByCollector";
+import handleMealExpired from "./handleMealExpired";
+import handleMealReceived from "./handleMealReceived";
+export {
+  handleMealBooked,
+  handleMealReservationCancelledByCollector,
+  handleMealExpired,
+  handleMealReceived,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "sonner": "^2.0.5",
         "tailwind-merge": "^3.0.2",
         "tailwindcss-animate": "^1.0.7",
+        "vaul": "^1.1.2",
         "zod": "^3.25.49"
       },
       "devDependencies": {
@@ -7160,6 +7161,19 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/vaul": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz",
+      "integrity": "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "sonner": "^2.0.5",
     "tailwind-merge": "^3.0.2",
     "tailwindcss-animate": "^1.0.7",
+    "vaul": "^1.1.2",
     "zod": "^3.25.49"
   },
   "devDependencies": {

--- a/providers/notification_provider.tsx
+++ b/providers/notification_provider.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+export type Notification = {
+  id: string;
+  title: string;
+  message: string;
+  link: string;
+  image?: string;
+  foodDesc?: string;
+  type:
+    | "meal_booked"
+    | "meal_received"
+    | "meal_expired"
+    | "meal_reservation_cancelled_by_collector";
+};
+
+type NotificationContextType = {
+  notifications: Notification[];
+  addNotification: (notification: Notification) => void;
+  removeNotification: (id: string) => void;
+  isDrawerOpen: boolean;
+  setIsDrawerOpen: (open: boolean) => void;
+  hasUnseenNotifications: boolean;
+  setHasUnseenNotifications: (hasUnseen: boolean) => void;
+};
+
+const NotificationContext = createContext<NotificationContextType | null>(null);
+
+export const useNotifications = () => {
+  const context = useContext(NotificationContext);
+  if (!context)
+    throw new Error(
+      "useNotifications must be used within NotificationProvider"
+    );
+  return context;
+};
+
+export function NotificationProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [notifications, setNotifications] = useState<Notification[]>(() => {
+    if (typeof window !== "undefined") {
+      const stored = localStorage.getItem("notifications");
+      return stored ? JSON.parse(stored) : [];
+    }
+    return [];
+  });
+
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [hasUnseenNotifications, setHasUnseenNotifications] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("notifications");
+    if (stored) setNotifications(JSON.parse(stored));
+  }, []);
+
+  const saveToStorage = (updated: Notification[]) => {
+    localStorage.setItem("notifications", JSON.stringify(updated));
+  };
+
+  const addNotification = (notification: Notification) => {
+    const current: Notification[] = JSON.parse(
+      localStorage.getItem("notifications") || "[]"
+    );
+
+    const updated = [
+      notification,
+      ...current.filter((n) => {
+        const currentMealId = n.link.split("/").pop();
+        const newMealId = notification.link.split("/").pop();
+        return currentMealId !== newMealId;
+      }),
+    ];
+    setNotifications(updated);
+    saveToStorage(updated);
+    setHasUnseenNotifications(true);
+  };
+
+  const removeNotification = (id: string) => {
+    const current: Notification[] = JSON.parse(
+      localStorage.getItem("notifications") || "[]"
+    );
+    const updated = current.filter((n) => n.id !== id);
+    setNotifications(updated);
+    saveToStorage(updated);
+  };
+
+  const handleDialogOpen = (open: boolean) => {
+    setIsDrawerOpen(open);
+    if (open) setHasUnseenNotifications(false);
+  };
+
+  return (
+    <NotificationContext.Provider
+      value={{
+        notifications,
+        addNotification,
+        removeNotification,
+        isDrawerOpen,
+        setIsDrawerOpen: handleDialogOpen,
+        hasUnseenNotifications,
+        setHasUnseenNotifications,
+      }}
+    >
+      {children}
+    </NotificationContext.Provider>
+  );
+}

--- a/providers/socket_provider.tsx
+++ b/providers/socket_provider.tsx
@@ -3,6 +3,14 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
 import { getSocket } from "@/lib/socket";
 import { Socket } from "socket.io-client";
+import {
+  handleMealBooked,
+  handleMealReservationCancelledByCollector,
+  handleMealExpired,
+  handleMealReceived,
+} from "@Events";
+import { useNotifications } from "./notification_provider";
+import { useQueryClient } from "@tanstack/react-query";
 
 type SocketContextType = {
   socket: Socket | null;
@@ -18,11 +26,11 @@ export default function SocketProvider({
   children: React.ReactNode;
 }) {
   const [socket, setSocket] = useState<Socket | null>(null);
-
+  const { addNotification, setHasUnseenNotifications } = useNotifications();
+  const queryClient = useQueryClient();
   useEffect(() => {
     const socketInstance = getSocket();
     socketInstance.connect();
-
     socketInstance.on("connect", () => {
       console.log("Connected to WebSocket");
       const userId = localStorage.getItem("donor_id");
@@ -33,23 +41,30 @@ export default function SocketProvider({
     });
 
     socketInstance.on("meal_booked", (data) => {
-      console.log(data);
-      alert(data.message);
+      const notification = handleMealBooked(data, queryClient);
+      addNotification(notification);
+      setHasUnseenNotifications(true);
     });
 
     socketInstance.on("meal_expired", (data) => {
-      console.log(data);
-      alert(data.message);
+      const notification = handleMealExpired(data, queryClient);
+      addNotification(notification);
+      setHasUnseenNotifications(true);
     });
 
     socketInstance.on("meal_received", (data) => {
-      console.log(data);
-      alert(data.message);
+      const notification = handleMealReceived(data, queryClient);
+      addNotification(notification);
+      setHasUnseenNotifications(true);
     });
 
     socketInstance.on("meal_reservation_cancelled_by_collector", (data) => {
-      console.log(data);
-      alert(data.message);
+      const notification = handleMealReservationCancelledByCollector(
+        data,
+        queryClient
+      );
+      addNotification(notification);
+      setHasUnseenNotifications(true);
     });
 
     socketInstance.on("disconnect", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,6 +34,8 @@
       "@UserHooks/*": ["api/user/hooks/*"],
       "@DonorHooks": ["api/donor/hooks"],
       "@DonorHooks/*": ["api/donor/hooks/*"],
+      "@Events": ["events"],
+      "@Events/*": ["events/*"],
       "@lib": ["lib"],
       "@lib/*": ["lib/*"],
       "@/*": ["./*"]


### PR DESCRIPTION
- Created a notification provider and context to handle notifications
- Added a bell icon that'll have a badge upon receiving the notification
- Added socket events handlers to handle specific events 
- Updated socket provider to generate the notifications 
- Added a drawer for the notifications.
- Invalidated queries for refetching 
- Notifications card are colored based on the event (like meal_booked, meal_cancelled)

**Run `npm i` after pulling the changes**

_Let me know if you have any doubts regarding the changes or any suggestions._